### PR TITLE
Update deprecated modules and use absolute paths for revealjs paths

### DIFF
--- a/lib/Mojolicious/Plugin/RevealJS.pm
+++ b/lib/Mojolicious/Plugin/RevealJS.pm
@@ -20,7 +20,6 @@ has home => sub {
 sub register {
   my ($plugin, $app, $conf) = @_;
   my $home = $plugin->home;
-
   push @{ $app->static->paths },   $home->rel_file('public');
   push @{ $app->renderer->paths }, $home->rel_file('templates');
 

--- a/lib/Mojolicious/Plugin/RevealJS.pm
+++ b/lib/Mojolicious/Plugin/RevealJS.pm
@@ -20,8 +20,8 @@ has home => sub {
 sub register {
   my ($plugin, $app, $conf) = @_;
   my $home = $plugin->home;
-  push @{ $app->static->paths },   $home->rel_dir('public');
-  push @{ $app->renderer->paths }, $home->rel_dir('templates');
+  push @{ $app->static->paths },   $home->rel_file('public');
+  push @{ $app->renderer->paths }, $home->rel_file('templates');
 
   $app->defaults('revealjs.init' => {
     controls => \1,

--- a/lib/Mojolicious/Plugin/RevealJS.pm
+++ b/lib/Mojolicious/Plugin/RevealJS.pm
@@ -44,7 +44,6 @@ sub _include_code {
     <pre><code class="<%= stash('language') // 'perl' %>" data-trim>
       <%= Mojo::File::slurp(app->home->rel_file($file)) =%>
     </code></pre>
-		<p><%= "file = $file" %></p>
     <p style="float: right; text-color: white; font-size: small;"><%= $file %></p>
   INCLUDE
   return b $html;

--- a/lib/Mojolicious/Plugin/RevealJS.pm
+++ b/lib/Mojolicious/Plugin/RevealJS.pm
@@ -20,6 +20,7 @@ has home => sub {
 sub register {
   my ($plugin, $app, $conf) = @_;
   my $home = $plugin->home;
+
   push @{ $app->static->paths },   $home->rel_file('public');
   push @{ $app->renderer->paths }, $home->rel_file('templates');
 
@@ -43,6 +44,7 @@ sub _include_code {
     <pre><code class="<%= stash('language') // 'perl' %>" data-trim>
       <%= Mojo::File::slurp(app->home->rel_file($file)) =%>
     </code></pre>
+		<p><%= "file = $file" %></p>
     <p style="float: right; text-color: white; font-size: small;"><%= $file %></p>
   INCLUDE
   return b $html;

--- a/lib/Mojolicious/Plugin/RevealJS.pm
+++ b/lib/Mojolicious/Plugin/RevealJS.pm
@@ -41,7 +41,7 @@ sub _include_code {
     % require Mojo::Util;
     % my $file = stash 'revealjs.private.file';
     <pre><code class="<%= stash('language') // 'perl' %>" data-trim>
-      <%= Mojo::Util::slurp(app->home->rel_file($file)) =%>
+      <%= Mojo::File::slurp(app->home->rel_file($file)) =%>
     </code></pre>
     <p style="float: right; text-color: white; font-size: small;"><%= $file %></p>
   INCLUDE

--- a/lib/Mojolicious/Plugin/RevealJS/files/templates/layouts/revealjs.html.ep
+++ b/lib/Mojolicious/Plugin/RevealJS/files/templates/layouts/revealjs.html.ep
@@ -14,27 +14,27 @@
 
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, minimal-ui">
 
-		<link rel="stylesheet" href="revealjs/css/reveal.css">
+		<link rel="stylesheet" href="/revealjs/css/reveal.css">
     <%
       my $theme = stash('theme') || 'black';
-      $theme = "revealjs/css/theme/$theme.css" unless $theme =~ /\.css$/;
+      $theme = "/revealjs/css/theme/$theme.css" unless $theme =~ /\.css$/;
     %>
     %= stylesheet $theme, id => 'theme'
 
 		<!-- Code syntax highlighting -->
-		<link rel="stylesheet" href="revealjs/lib/css/zenburn.css">
+		<link rel="stylesheet" href="/revealjs/lib/css/zenburn.css">
 
 		<!-- Printing and PDF exports -->
 		<script>
 			var link = document.createElement( 'link' );
 			link.rel = 'stylesheet';
 			link.type = 'text/css';
-			link.href = window.location.search.match( /print-pdf/gi ) ? 'revealjs/css/print/pdf.css' : 'revealjs/css/print/paper.css';
+			link.href = window.location.search.match( /print-pdf/gi ) ? '/revealjs/css/print/pdf.css' : '/revealjs/css/print/paper.css';
 			document.getElementsByTagName( 'head' )[0].appendChild( link );
 		</script>
 
 		<!--[if lt IE 9]>
-		<script src="revealjs/lib/js/html5shiv.js"></script>
+		<script src="/revealjs/lib/js/html5shiv.js"></script>
 		<![endif]-->
 
     %= include 'revealjs_head'
@@ -51,8 +51,8 @@
 
 		</div>
 
-		<script src="revealjs/lib/js/head.min.js"></script>
-		<script src="revealjs/js/reveal.js"></script>
+		<script src="/revealjs/lib/js/head.min.js"></script>
+		<script src="/revealjs/js/reveal.js"></script>
 
 		<script>
 			// Full list of configuration options available at:
@@ -67,12 +67,12 @@
       var init = <%== Mojo::JSON::to_json(\%opts) %>;
 			// Optional reveal.js plugins
       init.dependencies = [
-        { src: 'revealjs/lib/js/classList.js', condition: function() { return !document.body.classList; } },
-        { src: 'revealjs/plugin/markdown/marked.js', condition: function() { return !!document.querySelector( '[data-markdown]' ); } },
-        { src: 'revealjs/plugin/markdown/markdown.js', condition: function() { return !!document.querySelector( '[data-markdown]' ); } },
-        { src: 'revealjs/plugin/highlight/highlight.js', async: true, condition: function() { return !!document.querySelector( 'pre code' ); }, callback: function() { hljs.initHighlightingOnLoad(); } },
-        { src: 'revealjs/plugin/zoom-js/zoom.js', async: true },
-        { src: 'revealjs/plugin/notes/notes.js', async: true }
+        { src: '/revealjs/lib/js/classList.js', condition: function() { return !document.body.classList; } },
+        { src: '/revealjs/plugin/markdown/marked.js', condition: function() { return !!document.querySelector( '[data-markdown]' ); } },
+        { src: '/revealjs/plugin/markdown/markdown.js', condition: function() { return !!document.querySelector( '[data-markdown]' ); } },
+        { src: '/revealjs/plugin/highlight/highlight.js', async: true, condition: function() { return !!document.querySelector( 'pre code' ); }, callback: function() { hljs.initHighlightingOnLoad(); } },
+        { src: '/revealjs/plugin/zoom-js/zoom.js', async: true },
+        { src: '/revealjs/plugin/notes/notes.js', async: true }
       ];
 
       %= include 'revealjs_preinit', format => 'js'

--- a/t/presentation.t
+++ b/t/presentation.t
@@ -13,6 +13,16 @@ get '/' => {
   description => 'Everybody ❤️ Mojolicious',
 };
 
+under '/reveal';
+
+get '/nested_route' => { 
+  template => 'hello_talk',
+  layout => 'revealjs',
+  title => 'Hello World!',
+  author => 'JBERGER',
+  description => 'Everybody ❤️ Mojolicious',
+};
+
 my $t = Test::Mojo->new;
 
 $t->get_ok('/')
@@ -25,6 +35,11 @@ $t->get_ok('/')
   ->text_is('.reveal .slides section:nth-child(2) p' => 'code/hello.pl')
   ->element_exists('.reveal .slides pre code.html', 'language class applied')
   ->element_exists_not('.reveal .slides pre code.html #raw', 'contents of included files are html escaped');
+
+$t->get_ok('/reveal/nested_route')
+  ->status_is(200)
+	->element_exists('link[href="/revealjs/css/reveal.css"]')
+	->element_exists('script[src="/revealjs/lib/js/head.min.js"]');
 
 done_testing;
 


### PR DESCRIPTION
As discussed in [Mojolicious Forums](https://groups.google.com/forum/#!topic/mojolicious/22PKGB4gMjU), as the plugin uses relative paths it does not work on nested routes. This pull request adds absolute paths in revealjs template and updates deprecated modules. 